### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish to npm
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: 


### PR DESCRIPTION
Potential fix for [https://github.com/julianm-lrj/-julianm-lrj-node-instrumentation/security/code-scanning/5](https://github.com/julianm-lrj/-julianm-lrj-node-instrumentation/security/code-scanning/5)

In general, fix this by adding an explicit `permissions` block to the workflow or to individual jobs, granting only the minimum scopes that the workflow needs. For a simple publish-to-npm workflow that uses a separate `NPM_TOKEN`, GitHub repository access is only required for reading the code, so `contents: read` at the workflow or job level is sufficient.

For this specific file, the minimal, non-breaking change is to add a `permissions` block at the top level (so it applies to all jobs) right after the `name:` (or before/after the `on:` block), setting `contents: read`. No steps in the job write to issues, pull requests, or releases via `GITHUB_TOKEN`, and npm authentication uses `NODE_AUTH_TOKEN`, so we should not grant any write permissions. Concretely, in `.github/workflows/publish.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Publish to npm` and the `on:` block. No additional libraries, imports, or structural changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
