### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,6 +7,9 @@ on:
       - master
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julianm-lrj/-julianm-lrj-node-instrumentation/security/code-scanning/4](https://github.com/julianm-lrj/-julianm-lrj-node-instrumentation/security/code-scanning/4)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. Since this workflow just checks out code and runs Node.js tooling (`npm ci`, `lint`, `typecheck`, tests, coverage) without modifying repository resources, `contents: read` is sufficient, and is the minimal recommended setting for typical CI jobs that only need to read the code.

The best way to fix this without changing existing functionality is to add a workflow-level `permissions` block near the top of `.github/workflows/code-quality.yml`, so it applies to all jobs (there is only one job, `code-quality`). Specifically, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 9 and before line 10 in the provided snippet). No imports or other code changes are needed, as this is purely a configuration hardening change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
